### PR TITLE
fix error handling and add available tickets for the other events

### DIFF
--- a/src/components/createEvent.js
+++ b/src/components/createEvent.js
@@ -186,18 +186,27 @@ export const createEvent = ({
                     quantity: +quantity,
                 }),
             })
-                .then((response) => response.json())
-                .then((data) => {
-                    removeLoader();
-                    addPurchase(data); // Call the updated addPurchase function
-                    input.value = 0;
-                    addToCart.disabled = true;
-                    toastr.success('Success!');
-                })
-                .catch((error) => {
-                    console.error('Error saving purchased event:', error);
-                    toastr.error('Error!');
+            .then((response) => {
+                return response.json().then((data) => {
+                  if (!response.ok) {
+                    throw new Error(data.message);
+                  } 
+      
+                  return data;
                 });
+            })
+            .then((data) => {
+                addPurchase(data); // Call the updated addPurchase function
+                input.value = 0;
+                addToCart.disabled = true;
+                toastr.success('Success!');
+            })
+            .catch((error) => {
+                console.error('Error saving purchased event:', error);
+                toastr.error('Error!');
+            }).finally(() => {
+                removeLoader();
+            });
         } else {
             // Handle the case when quantity is not a valid number
             // Maybe show an error message to the user

--- a/src/mocks/handlers.js
+++ b/src/mocks/handlers.js
@@ -83,11 +83,7 @@ const handlers = [
       });
 
       if (tickets.length < quantity) {
-        return res(
-          ctx.status(400),
-          ctx.delay(),
-          ctx.json({ message: 'Quantity is to large' })
-        );
+        throw new Error('Quantity is too large');
       }
 
       const order = db.order.create({
@@ -105,12 +101,12 @@ const handlers = [
       });
 
       return res(ctx.status(200), ctx.delay(), ctx.json(order));
-    } catch {
+    } catch (e) {
       return res(
         ctx.status(400),
         ctx.delay(),
         ctx.json({
-          message: 'Event not found',
+          message: e.message,
         })
       );
     }

--- a/src/mocks/migrations.js
+++ b/src/mocks/migrations.js
@@ -70,7 +70,7 @@ const makeSportsEvent = () => {
     capacity: 30_200,
   });
 
-  db.event.create({
+  const athletismEvent = db.event.create({
     eventType: sportsEventType,
     venue: sportsVenue,
     ticketCategories: [standardCategory, vipCategory],
@@ -83,6 +83,17 @@ const makeSportsEvent = () => {
       height: 128,
       width: 128,
     }),
+  });
+
+  Array.from({ length: 6 }).forEach((_, index) => {
+    db.ticket.create({
+      ticketCategory: faker.helpers.arrayElement([
+        standardCategory,
+        vipCategory,
+      ]),
+      event: athletismEvent,
+      seat: ++index,
+    });
   });
 };
 
@@ -99,7 +110,7 @@ const makeRandomEvent = () => {
 
   const name = faker.lorem.word();
 
-  db.event.create({
+  const randomEvent = db.event.create({
     eventType: randomEventType,
     venue: randomVenue,
     ticketCategories: [standardCategory, vipCategory],
@@ -112,6 +123,17 @@ const makeRandomEvent = () => {
       height: 128,
       width: 128,
     }),
+  });
+
+  Array.from({ length: 3 }).forEach((_, index) => {
+    db.ticket.create({
+      ticketCategory: faker.helpers.arrayElement([
+        standardCategory,
+        vipCategory,
+      ]),
+      event: randomEvent,
+      seat: ++index,
+    });
   });
 };
 


### PR DESCRIPTION
1) **Create tickets for all events.**
Expectations: Now we can buy tickets for any event so that they appear in the order list page. Before, only the first event could be added.
2) **Correct management of errors for the purchase process**.
Expectations: Now if there are no more tickets available or if an error occurs, we will catch it and we will have the error toast + the correct error in the console.
Before, the success toast appeared when the request fails (so even if the purchase is not completed).

Teams ticket: https://teams.microsoft.com/l/entity/com.microsoft.teamspace.tab.planner/tt.c_19:f03d4770775847c0b2b65a82128980e0@thread.tacv2_p_65T5yrSpUkqx7UIo1CtwupYAFSdD_h_1686558661714?tenantId=0b3fc178-b730-4e8b-9843-e81259237b77&webUrl=https%3A%2F%2Ftasks.teams.microsoft.com%2Fteamsui%2FpersonalApp%2Falltasklists&context=%7B%22subEntityId%22%3A%22%2Fboard%2Ftask%2FdUTETF1CKE2K7jtJPBhxRZYAHEyu%22%2C%22channelId%22%3A%2219%3Af03d4770775847c0b2b65a82128980e0%40thread.tacv2%22%7D